### PR TITLE
Fixed caching files locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,18 +49,37 @@ azurecopy -configdropbox
 Again, follow the instructions and the config file will be automatically modified for you.
 
 
-Examples:
+### Examples:
 
 
-S3 to Azure using regular copy:   azurecopy.exe -i https://mybucket.s3.amazonaws.com/myblob -o https://myaccount.blob.core.windows.net/mycontainer
-S3 to Azure using blob copy api (better for local bandwidth: azurecopy.exe -i https://mybucket.s3.amazonaws.com/myblob -o https://myaccount.blob.core.windows.net/mycontainer -blobcopy
-Azure to S3: azurecopy.exe -i https://myaccount.blob.core.windows.net/mycontainer/myblob -o https://mybucket.s3.amazonaws.com/ 
-List contents in S3 bucket: azurecopy.exe -list https://mybucket.s3.amazonaws.com/
-List contents in Azure container: azurecopy.exe -list https://myaccount.blob.core.windows.net/mycontainer/ 
-Onedrive to local using regular copy: azurecopy.exe -i sky://temp/myfile.txt -o c:\\temp\\");
-Dropbox to local using regular copy: azurecopy.exe -i https://dropbox.com/temp/myfile.txt -o c:\\temp\\
+- S3 to Azure using regular copy:   
 
-More examples will be added directly to AzureCopy which you can see by running the command:
+`azurecopy.exe -i https://mybucket.s3.amazonaws.com/myblob -o https://myaccount.blob.core.windows.net/mycontainer`
 
-azurecopy -examples
+- S3 to Azure using blob copy api (better for local bandwidth:
 
+`azurecopy.exe -i https://mybucket.s3.amazonaws.com/myblob -o https://myaccount.blob.core.windows.net/mycontainer -blobcopy`
+
+- Azure to S3: 
+
+`azurecopy.exe -i https://myaccount.blob.core.windows.net/mycontainer/myblob -o https://mybucket.s3.amazonaws.com/`
+
+- List contents in S3 bucket: 
+
+`azurecopy.exe -list https://mybucket.s3.amazonaws.com/`
+
+- List contents in Azure container: 
+
+`azurecopy.exe -list https://myaccount.blob.core.windows.net/mycontainer/`
+
+- Onedrive to local using regular copy: 
+
+`azurecopy.exe -i sky://temp/myfile.txt -o c:\\temp\\"`
+
+- Dropbox to local using regular copy: 
+
+`azurecopy.exe -i https://dropbox.com/temp/myfile.txt -o c:\\temp\\`
+
+- More examples will be added directly to AzureCopy which you can see by running the command:
+
+`azurecopy -examples`

--- a/azurecopy/Helpers/CommonHelper.cs
+++ b/azurecopy/Helpers/CommonHelper.cs
@@ -37,6 +37,9 @@ namespace azurecopy.Utils
             // get stream to data.
             if (!string.IsNullOrEmpty(fileName))
             {
+                string directory = Path.GetDirectoryName(fileName);
+                if (!Directory.Exists(directory))  Directory.CreateDirectory(directory);
+
                 stream = new FileStream(fileName, FileMode.Create);
             }
             else

--- a/azurecopy/dummy_App.config
+++ b/azurecopy/dummy_App.config
@@ -26,6 +26,9 @@
     <add key="ClientId" value="000000004407DDB4"/>
     <add key="SkyDriveCode" value="please populate"/>
     <add key="SkyDriveRefreshToken" value=""/>
+
+    <!-- Cache files by saving them locally. It might be required when copying large files. -->
+    <add key="AmDownloading" value="false" />
     
   </appSettings>
 </configuration>


### PR DESCRIPTION
I had to copy huge files between S3 and Azure. When I ran it normally I ran out of memory and program crashed. I added publicly option to cache files locally and I added automatic creating cache directories.

Changes:
- Added option to cache files locally to config file
- Added creating folders when caching files locally
- Updated README for better readability